### PR TITLE
Add support for tracking requests

### DIFF
--- a/lib/data/payload.ex
+++ b/lib/data/payload.ex
@@ -96,7 +96,14 @@ defmodule ExInsights.Data.Payload do
   @doc """
   Create request payload
   """
-  def create_request_payload(name, url, source \\ nil, elapsed_time_ms, resultCode, success) do
+  def create_request_payload(name, url, source \\ nil, elapsed_time_ms, resultCode, success \\ nil) do
+    success =
+      if nil == success do
+        resultCode >= 200 and resultCode < 300
+      else
+        success
+      end
+
     %{
       name: name,
       url: url,

--- a/lib/data/payload.ex
+++ b/lib/data/payload.ex
@@ -93,6 +93,22 @@ defmodule ExInsights.Data.Payload do
     |> create_payload("RemoteDependency")
   end
 
+  @doc """
+  Create request payload
+  """
+  def create_request_payload(name, url, source \\ nil, elapsed_time_ms, resultCode, success) do
+    %{
+      name: name,
+      url: url,
+      id: Base.encode16(<<:rand.uniform(438964124) :: size(32)>>),
+      source: source,
+      duration: Utils.ms_to_timespan(elapsed_time_ms),
+      responseCode: resultCode,
+      success: success
+    }
+    |> create_payload("Request")
+  end
+
   defp create_payload(data, type) do
     data
     |> Envelope.create(type, DateTime.utc_now(), Conf.get_value(:instrumentation_key), Envelope.get_tags())

--- a/lib/ex_insights.ex
+++ b/lib/ex_insights.ex
@@ -135,6 +135,27 @@ defmodule ExInsights do
     |> track()
   end
 
+
+  @doc ~S"""
+  Log a request, for example incoming HTTP requests
+
+  ### Parameters:
+
+  ```
+  name: String that identifies the request
+  url: Request URL
+  source: Request Source. Encapsultes info about the component that initiated the request
+   elapsed_time_ms: Number for elapsed time in milliseconds
+   resultCode: Result code reported by the application
+   success: whetever the request was successfull. by default check for 2xx result codes
+  ```
+  """
+  @spec track_request(name :: name, String.t, String.t, number, String.t | number, boolean) :: :ok
+  def track_request(name, url, source \\ nil, elapsed_time_ms, resultCode, success \\ nil) do
+    Payload.create_request_payload(name, url, source, elapsed_time_ms, resultCode, success)
+    |> track
+  end
+
   @spec track(map) :: :ok
   defp track(payload) do
     ExInsights.Aggregation.Worker.track(payload)


### PR DESCRIPTION
Enables tracking of  [Request Telemetry](https://docs.microsoft.com/en-us/azure/application-insights/application-insights-data-model-request-telemetry) (HTTP or otherwise).