### PR TITLE
Add start time and dependency id parameters

### DIFF
--- a/lib/data/payload.ex
+++ b/lib/data/payload.ex
@@ -115,6 +115,7 @@ defmodule ExInsights.Data.Payload do
   def create_dependency_payload(
         name,
         command_name,
+        start_time,
         elapsed_time_ms,
         success,
         dependency_type_name,
@@ -131,7 +132,7 @@ defmodule ExInsights.Data.Payload do
       type: dependency_type_name,
       properties: properties
     }
-    |> create_payload("RemoteDependency", tags)
+    |> create_payload("RemoteDependency", tags, start_time)
   end
 
   @doc """
@@ -141,6 +142,7 @@ defmodule ExInsights.Data.Payload do
         name,
         url,
         source,
+        start_time,
         elapsed_time_ms,
         result_code,
         success,
@@ -160,15 +162,19 @@ defmodule ExInsights.Data.Payload do
       properties: properties,
       measurements: measurements
     }
-    |> create_payload("Request", tags)
+    |> create_payload("Request", tags, start_time)
   end
 
-  @spec create_payload(data :: map(), type :: String.t(), tags :: map()) :: Envelope.t()
-  defp create_payload(data, type, tags) do
+  @spec create_payload(
+    data :: map(),
+    type :: String.t(),
+    tags :: map()) :: Envelope.t(),
+    start_time :: DateTime | nil
+  defp create_payload(data, type, tags, start_time \\ nil) do
     data
     |> Envelope.create(
       type,
-      DateTime.utc_now(),
+      start_time || DateTime.utc_now(),
       Map.merge(Envelope.get_tags(), tags)
     )
   end

--- a/lib/data/payload.ex
+++ b/lib/data/payload.ex
@@ -121,10 +121,12 @@ defmodule ExInsights.Data.Payload do
         dependency_type_name,
         target,
         properties,
-        tags
+        tags,
+        id
       ) do
     %{
       name: name,
+      id: id,
       data: command_name,
       target: target,
       duration: Utils.ms_to_timespan(elapsed_time_ms),

--- a/lib/decoration/attributes.ex
+++ b/lib/decoration/attributes.ex
@@ -25,11 +25,11 @@ defmodule ExInsights.Decoration.Attributes do
       args = unquote(args)
       type = unquote(type)
 
-      start = :os.timestamp()
+      start = DateTime.utc_now()
 
       try do
         result = unquote(body)
-        finish = :os.timestamp()
+        finish = DateTime.utc_now()
         # success = true
         success = ExInsights.Decoration.Attributes.success?(result)
 
@@ -46,7 +46,7 @@ defmodule ExInsights.Decoration.Attributes do
         result
       rescue
         e ->
-          finish = :os.timestamp()
+          finish = DateTime.utc_now()
           trace = System.stacktrace()
 
           ExInsights.Decoration.Attributes.do_track_dependency(
@@ -62,7 +62,7 @@ defmodule ExInsights.Decoration.Attributes do
           reraise(e, trace)
       catch
         :exit, reason ->
-          finish = :os.timestamp()
+          finish = DateTime.utc_now()
 
           ExInsights.Decoration.Attributes.do_track_dependency(
             start,
@@ -83,10 +83,10 @@ defmodule ExInsights.Decoration.Attributes do
   def success?(_), do: true
 
   def do_track_dependency(start, finish, module, name, args, type, success) do
-    diff = ExInsights.Utils.diff_timestamp_millis(start, finish)
+    diff_ms = DateTime.diff(finish, start, :millisecond)
 
     "#{inspect(module)}.#{name}"
-    |> ExInsights.track_dependency(inspect(args), diff, success, type)
+    |> ExInsights.track_dependency(inspect(args), start, diff_ms, success, type)
   end
 
   def track_exception(body, _context) do

--- a/lib/ex_insights.ex
+++ b/lib/ex_insights.ex
@@ -192,6 +192,7 @@ defmodule ExInsights do
   dependency_type_name: String which denotes dependency type. Defaults to nil.
   target: String of the target host of the dependency.
   properties (optional): map[string, string] - additional data used to filter events and metrics in the portal. Defaults to empty.
+  id (optional): a unique identifier representing the dependency call.
   tags (optional): map[string, string] - additional application insights tag metadata.
   instrumentation_key (optional): Azure application insights API key. If not set it will be read from the configuration (see README.md)
   ```
@@ -206,6 +207,7 @@ defmodule ExInsights do
           String.t(),
           String.t() | nil,
           properties :: properties,
+          id :: String.t() | nil,
           tags :: tags,
           instrumentation_key :: instrumentation_key
         ) :: :ok
@@ -218,9 +220,12 @@ defmodule ExInsights do
         dependency_type_name \\ "",
         target \\ nil,
         properties \\ %{},
+        id \\ nil,
         tags \\ %{},
         instrumentation_key \\ nil
       ) do
+    id = if id == nil, do: Base.encode16(<<:rand.uniform(438_964_124)::size(32)>>), else: id
+
     Payload.create_dependency_payload(
       name,
       command_name,
@@ -230,7 +235,8 @@ defmodule ExInsights do
       dependency_type_name,
       target,
       properties,
-      tags
+      tags,
+      id
     )
     |> track(instrumentation_key)
   end

--- a/lib/ex_insights.ex
+++ b/lib/ex_insights.ex
@@ -186,6 +186,7 @@ defmodule ExInsights do
   ```
   name: String that identifies the dependency.
   command_name: String of the name of the command made against the dependency (eg. full URL with querystring or SQL command text).
+  start_time: The datetime when the dependency call was initiated.
   elapsed_time_ms: Number for elapsed time in milliseconds of the command made against the dependency.
   success: Boolean which indicates success.
   dependency_type_name: String which denotes dependency type. Defaults to nil.
@@ -199,6 +200,7 @@ defmodule ExInsights do
   @spec track_dependency(
           name :: name,
           String.t(),
+          DateTime,
           number,
           boolean,
           String.t(),
@@ -210,6 +212,7 @@ defmodule ExInsights do
   def track_dependency(
         name,
         command_name,
+        start_time,
         elapsed_time_ms,
         success,
         dependency_type_name \\ "",
@@ -221,6 +224,7 @@ defmodule ExInsights do
     Payload.create_dependency_payload(
       name,
       command_name,
+      start_time,
       elapsed_time_ms,
       success,
       dependency_type_name,
@@ -240,6 +244,7 @@ defmodule ExInsights do
   name: String that identifies the request
   url: Request URL
   source: Request Source. Encapsulates info about the component that initiated the request (can be nil)
+  start_time: The datetime when the request was initiated.
   elapsed_time_ms: Number for elapsed time in milliseconds
   result_code: Result code reported by the application
   success: whether the request was successfull
@@ -254,6 +259,7 @@ defmodule ExInsights do
           name :: name,
           url :: String.t(),
           source :: String.t() | nil,
+          start_time :: DateTime,
           elapsed_time_ms :: number,
           result_code :: String.t() | number,
           success :: boolean,
@@ -268,6 +274,7 @@ defmodule ExInsights do
         name,
         url,
         source,
+        start_time,
         elapsed_time_ms,
         result_code,
         success,
@@ -283,6 +290,7 @@ defmodule ExInsights do
       name,
       url,
       source,
+      start_time,
       elapsed_time_ms,
       result_code,
       success,

--- a/test/ex_insights_test.exs
+++ b/test/ex_insights_test.exs
@@ -42,6 +42,7 @@ defmodule ExInsightsTest do
         Payload.create_dependency_payload(
           "get_user_balance",
           "http://my.api/get_balance/rfostini",
+          DateTime.utc_now(),
           1500,
           true,
           "user",
@@ -71,6 +72,7 @@ defmodule ExInsightsTest do
           "homepage",
           "http://my.site/",
           "homeModule",
+          DateTime.utc_now(),
           140,
           200,
           true,

--- a/test/ex_insights_test.exs
+++ b/test/ex_insights_test.exs
@@ -48,7 +48,8 @@ defmodule ExInsightsTest do
           "user",
           "my.api",
           %{},
-          %{"ai.operation.id": "foo_id"}
+          %{"ai.operation.id": "foo_id"},
+          "random_id"
         )
 
       assert %{
@@ -57,7 +58,8 @@ defmodule ExInsightsTest do
                duration: "00:00:01.500",
                success: true,
                type: "user",
-               target: "my.api"
+               target: "my.api",
+               id: "random_id"
              } = envelope.data.baseData
         assert %{
         "ai.operation.id": "foo_id",


### PR DESCRIPTION
This PR does two things, and it's a breaking change again.

1. Add `start_time` parameter to `track_request` and `track_dependency`.  The typical flow for tracking requests and dependencies is to start a timer when the request is started, and log it with both the duration and start time.  Currently, ex_insights always uses `DateTime.utc_now()` for the start time, which results in inaccurate logging data.

2. Add `id` parameter to `track_dependency`.  Like requests, dependency calls can also take an `id` which uniquely identifies them in application insights.  This also enables a parent-child relationship in app insights, where the dependency is the parent item.  Without the ability to provide the `id`, this relationship is not possible.